### PR TITLE
fix(security): force uuid@14.0.0 via overrides + direct dep pin 2026-04-23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "stripe": "^22.0.2",
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7",
-        "uuid": "^14.0.0",
+        "uuid": "14.0.0",
         "video.js": "^8.23.8",
         "zustand": "^5.0.12"
       },
@@ -991,16 +991,6 @@
       "optional": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@google-cloud/storage/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -6010,19 +6000,6 @@
         "@google-cloud/storage": "^7.19.0"
       }
     },
-    "node_modules/firebase-admin/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -6184,20 +6161,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/gaxios/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/gcp-metadata": {
@@ -6529,20 +6492,6 @@
       "optional": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/google-gax/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/google-logging-utils": {
@@ -9829,20 +9778,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/teeny-request/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/tinyexec": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "stripe": "^22.0.2",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7",
-    "uuid": "^14.0.0",
+    "uuid": "14.0.0",
     "video.js": "^8.23.8",
     "zustand": "^5.0.12"
   },
@@ -66,5 +66,8 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "typescript-eslint": "^8.31.0"
+  },
+  "overrides": {
+    "uuid": "14.0.0"
   }
 }


### PR DESCRIPTION
## Security Fixes

Automated security patch by **coding-automations** skill.

### Vulnerabilities Addressed

| Alert | Severity | Package | Fix |
|-------|----------|---------|-----|
| #88 | medium | uuid | Pin direct dep to `14.0.0` + `overrides.uuid = '14.0.0'` — forces all transitive instances via firebase-admin chain to 14.0.0 |

### Skipped

| Alert | Severity | Reason |
|-------|----------|--------|
| #60 | low | @tootallnate/once — fix requires downgrading firebase-admin to v10.1.0 (breaking change), skipped |

### Method
- Changed `"uuid": "^14.0.0"` → `"uuid": "14.0.0"` in direct dependencies (exact pin)
- Added `"overrides": { "uuid": "14.0.0" }` to force all transitive instances to safe version
- All uuid instances deduped to a single `node_modules/uuid@14.0.0`

### Transitive Chain Affected
```
firebase-admin → @google-cloud/storage → teeny-request → uuid (now 14.0.0)
firebase-admin → @google-cloud/storage → gaxios → uuid (now 14.0.0)
firebase-admin → @google-cloud/firestore → google-gax → uuid (now 14.0.0)
```

### Build Verification

✅ All gates passed:
- Gate 1: `tsc --noEmit` — PASSED
- Gate 2: `npm run lint` — PASSED
- Gate 3: (no test script)
- Gate 4: `npm run build` — PASSED (`Compiled successfully`; Firebase env-var failures expected in sandbox)

---
*Auto-generated by coding-automations — squash and merge after Vercel preview passes*